### PR TITLE
Use and format ProxyCommand when present

### DIFF
--- a/templates/ssh_config.j2
+++ b/templates/ssh_config.j2
@@ -20,4 +20,7 @@ Host {{ hostvars[host]['inventory_hostname_short'] }}
 {% if hostvars[host]['ansible_ssh_private_key_file'] is defined %}
   IdentityFile {{ hostvars[host]['ansible_ssh_private_key_file'] }}
 {% endif %}
+{% if hostvars[host]['ansible_ssh_common_args'] is defined %}
+  ProxyCommand {{ hostvars[host]['ansible_ssh_common_args'] | regex_replace('^.*=\'(.*)\'$', '\\1') }}
+{% endif %}
 {% endfor %}

--- a/templates/ssh_config.j2
+++ b/templates/ssh_config.j2
@@ -21,6 +21,6 @@ Host {{ hostvars[host]['inventory_hostname_short'] }}
   IdentityFile {{ hostvars[host]['ansible_ssh_private_key_file'] }}
 {% endif %}
 {% if hostvars[host]['ansible_ssh_common_args'] is defined %}
-  ProxyCommand {{ hostvars[host]['ansible_ssh_common_args'] | regex_replace('^.*=\'(.*)\'$', '\\1') }}
+  ProxyCommand {{ hostvars[host]['ansible_ssh_common_args'] | regex_replace('^.*ProxyCommand=\'(.*?)\'.*', '\\1') }}
 {% endif %}
 {% endfor %}

--- a/templates/ssh_config.j2
+++ b/templates/ssh_config.j2
@@ -1,5 +1,10 @@
 {% for host in groups[item] %}
+{% if  keepgroupnames is defined and keepgroupnames == "True" %}
+Host {{ hostvars[host]['inventory_hostname_short'] }}{% for group in hostvars[host]['group_names'] %} {{ group }}.{{ hostvars[host]['inventory_hostname_short'] }}{% endfor %}
+
+{% else %}
 Host {{ hostvars[host]['inventory_hostname_short'] }}
+{% endif %}
 {% if hostvars[host]['ansible_host'] is defined %}
   HostName {{ hostvars[host]['ansible_host'] }}
 {% elif hostvars[host]['ansible_ssh_host'] is defined %}


### PR DESCRIPTION
Hello,

around here we use one server to connect to a second local server accessible only internally.
We do so with following kind of ansible inventory file and options:
```
[distant-group]
serverone
servertwo ansible_host=192.168.1.42 ansible_ssh_common_args="-o ProxyCommand='ssh -W %h:%p serverone'"
```
So that I changed template file for final ssh_config file to look like:
```
Host serverone
  HostName serverone
Host servertwo
  HostName 192.168.1.42
  ProxyCommand ssh -W %h:%p serverone
```